### PR TITLE
Fix `extends M.C` highlight in `JavaScript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## 0.0.20
 
 - Improve `TypeScript` highlight: `enum` is now highlighted properly, #27
+- Improve `JavaScript` highlight:
+  `extends Module.Class` is now highlighted properly, #26
 
 ## 0.0.19
 

--- a/test/JSX.jsx
+++ b/test/JSX.jsx
@@ -13,3 +13,13 @@ export const Main = () =>
     <Component a="text" />
     <Component b=1 />
   </div>
+
+
+export class MyClassComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      count: 0,
+    }
+  }
+}

--- a/themes/pustota-color-theme.json
+++ b/themes/pustota-color-theme.json
@@ -480,6 +480,7 @@
 
         // JS:
         "string.template meta.template",  // expressions inside `${}`
+        "meta.class entity.name.type.module.js",  // `class A extends M.C`
         // TS:
         "meta.type.annotation entity.name.type",
         "meta.return.type entity.name.type",


### PR DESCRIPTION
Closes #26

After:
<img width="627" alt="Снимок экрана 2025-01-21 в 08 57 00" src="https://github.com/user-attachments/assets/3385d62b-9bcf-4891-86f3-14fcda88a9cd" />
